### PR TITLE
Merge instance manager aliasing

### DIFF
--- a/library/Rediska/Manager.php
+++ b/library/Rediska/Manager.php
@@ -62,6 +62,17 @@ class Rediska_Manager
     }
 
     /**
+     * Add a Rediska-instance under a special alias.
+     *
+     * @param Rediska $rediska The rediska instance that should be added
+     * @param string $alias The alias-name under which the instance should be reachable.
+     */
+    public static function addAlias(Rediska $rediska, $alias)
+    {
+        self::$_instances[$alias]=$rediska;
+    }
+
+    /**
      * Has Rediska instances
      *
      * @param string $name

--- a/tests/library/Rediska/ManagerTest.php
+++ b/tests/library/Rediska/ManagerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+
+/**
+ * Tests if Manager works as expected.
+ */
+class ManagerTest extends Rediska_TestCase
+{
+    function testDefaultInstance()
+    {
+        $rediska=new Rediska();
+
+        $this->assertSame($rediska,Rediska_Manager::get());
+    }
+
+    function testAddAlias()
+    {
+        $rediska=new Rediska();
+        Rediska_Manager::addAlias($rediska,"testalias");
+        $this->assertSame($rediska,Rediska_Manager::get());
+        $this->assertSame($rediska,Rediska_Manager::get("testalias"));
+
+        $rediska2=new Rediska();
+        Rediska_Manager::addAlias($rediska2,"secondinstance");
+        $this->assertSame($rediska2,Rediska_Manager::get("secondinstance"));
+        $this->assertNotSame($rediska2,Rediska_Manager::get());
+        $this->assertNotSame($rediska2,Rediska_Manager::get("testalias"));
+    }
+}
+
+
+
+
+

--- a/tests/library/Rediska/ManagerTest.php
+++ b/tests/library/Rediska/ManagerTest.php
@@ -20,9 +20,10 @@ class ManagerTest extends Rediska_TestCase
         $this->assertSame($rediska,Rediska_Manager::get());
         $this->assertSame($rediska,Rediska_Manager::get("testalias"));
 
-        $rediska2=new Rediska();
-        Rediska_Manager::addAlias($rediska2,"secondinstance");
+        $rediska2=new Rediska(array("name"=>"secondinstance"));
+        Rediska_Manager::addAlias($rediska2,"secondinstance_alias");
         $this->assertSame($rediska2,Rediska_Manager::get("secondinstance"));
+        $this->assertSame($rediska2,Rediska_Manager::get("secondinstance_alias"));
         $this->assertNotSame($rediska2,Rediska_Manager::get());
         $this->assertNotSame($rediska2,Rediska_Manager::get("testalias"));
     }

--- a/tests/redis.conf
+++ b/tests/redis.conf
@@ -7,4 +7,3 @@ bind 127.0.0.1
 appendonly no 
 appendfsync no 
 no-appendfsync-on-rewrite no 
-vm-enabled no

--- a/tests/redis2.conf
+++ b/tests/redis2.conf
@@ -7,4 +7,3 @@ bind 127.0.0.1
 appendonly no 
 appendfsync no 
 no-appendfsync-on-rewrite no 
-vm-enabled no


### PR DESCRIPTION
This so so that we get a complete version inside our fork so we can use it as composer dependency and get rid of our copy in DiLoc.