### PR TITLE
Squash feature/DLR-8907-fix-problems-detected-in-epf-for-7.4-8.3

### DIFF
--- a/library/Rediska/Serializer/Adapter/PhpSerialize.php
+++ b/library/Rediska/Serializer/Adapter/PhpSerialize.php
@@ -51,9 +51,9 @@ class Rediska_Serializer_Adapter_PhpSerialize implements Rediska_Serializer_Adap
     /**
      * Catch unserialize notice
      */
-    public function catchUnserializeNotice($errno, $errstr, $errfile, $errline, $errcontext)
+    public function catchUnserializeNotice($errno, $errstr, $errfile, $errline)
     {
-        if (!error_reporting() && strpos($errstr, 'unserialize()') !== false) {
+        if (strpos($errstr, 'unserialize()') !== false) {
             $this->_unserialized = false;
             return true;
         } else {


### PR DESCRIPTION
Fix for PHP 8.3 compatibility:
 - error handler use 4 parameters only.
 - `error_reporting()` return changed when run with the error control operator `@` (previously returned 0, now returns the original configured error level)